### PR TITLE
Work around Yarn bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "stop": "^3.0.0-rc1",
     "stylus": "*",
     "twbs": "0.0.6",
-    "uglify-js": "*"
+    "uglify-js": "^2.4.19"
   },
   "component": {
     "scripts": {


### PR DESCRIPTION
Per https://github.com/yarnpkg/yarn/issues/3181, Yarn does not deal with multiple dependency
versions properly and, in this case, accepts any uglify-js version (per the `*` version previously
written in devDependencies) when generating yarn.lock. It should instead ensure that a version
compatible with ^2.4.19 is installed. By replacing the wildcard version with ^2.4.19, we ensure that
a valid uglify-js version is installed for Jade.